### PR TITLE
Fix mod-aoe-loot compile error and restore AoE trigger on normal loot

### DIFF
--- a/src/aoe_loot.cpp
+++ b/src/aoe_loot.cpp
@@ -20,7 +20,6 @@
 #include "ObjectMgr.h"
 
 using namespace Acore::ChatCommands;
-using namespace WorldPackets;
 
 std::map<uint64, bool> AoeLootCommandScript::playerAoeLootEnabled;
 std::map<uint64, bool> AoeLootCommandScript::playerAoeLootDebug;
@@ -30,7 +29,7 @@ std::map<uint64, bool> AoeLootCommandScript::playerAoeLootDebug;
 
 // >>>>> This is the entry point. This packet triggers the AOE loot system. <<<<< //
 
-bool AoeLootManager::CanPacketReceive(WorldSession* session, WorldPacket& packet)
+bool AoeLootManager::CanPacketReceive(WorldSession* session, WorldPacket const& packet)
 {
     if (packet.GetOpcode() == CMSG_LOOT)
     {

--- a/src/aoe_loot.h
+++ b/src/aoe_loot.h
@@ -27,7 +27,7 @@ class AoeLootManager : public ServerScript
 public:
     AoeLootManager() : ServerScript("AoeLootManager") {}
     
-    bool CanPacketReceive(WorldSession* session, WorldPacket& packet) override;
+    bool CanPacketReceive(WorldSession* session, WorldPacket const& packet) override;
 };
 
 // AoeLootManager Class End. >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> //


### PR DESCRIPTION
## Summary
This PR fixes two regressions in `mod-aoe-loot` on newer AzerothCore and AzerothCore/playerbots code paths.

## What Was Broken
1. Build failure with ambiguous `Item` reference.
2. AoE loot only triggered when manually running `.aoeloot startaoeloot`, not during normal loot interaction.

## Root Cause
1. A global `using namespace WorldPackets;` introduced a name collision with `Item`.
2. The packet hook used the non-const packet signature, while the current dispatch path uses the `const` overload, so the module hook was not being called during normal loot flow.

## What Changed
1. Removed the unused `WorldPackets` namespace import from [src/aoe_loot.cpp](https://github.com/Jellypowered/mod-aoe-loot/blob/main/src/aoe_loot.cpp).
   - This line was not used by the module and could cause naming conflicts in some builds, breaking compilation.

2. Updated the server hook override to match the `const` packet signature in:
   - [src/aoe_loot.h](https://github.com/Jellypowered/mod-aoe-loot/blob/main/src/aoe_loot.h)
   - [src/aoe_loot.cpp](https://github.com/Jellypowered/mod-aoe-loot/blob/main/src/aoe_loot.cpp)

## Result
1. Module compiles successfully.
2. Normal creature looting now correctly triggers AoE loot behavior again.

## Testing
1. Built with the standard command: `./acore.sh compiler build`
2. Verified compile success and confirmed AoE loot triggers from regular loot interaction, not only from manual command execution.

## Compare
Upstream to fork comparison:  
[Compare TerraByte-tbwps/main to Jellypowered/main](https://github.com/TerraByte-tbwps/mod-aoe-loot/compare/main...Jellypowered:main)